### PR TITLE
Add disableExceptionHandling function for easier testing in TestCase.php

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -70,20 +70,20 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Disables the exception handling function and throws the exception instead.
-     * 
+     *
      * @return Throwable $e
      */
     protected function disableExceptionHandling()
     {
-        $this->app->instance(ExceptionHandler::class, new class extends Handler{
-            public function __construct() 
+        $this->app->instance(ExceptionHandler::class, new class extends Handler {
+            public function __construct()
             {
-
             }
-            public function report(Exception $e) 
+
+            public function report(Exception $e)
             {
-
             }
+
             public function render($request, Exception $e)
             {
                 throw $e;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -69,15 +69,21 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
-     * Disables the exception handling function and throws the exception instead
+     * Disables the exception handling function and throws the exception instead.
      * 
      * @return Throwable $e
      */
     protected function disableExceptionHandling()
     {
         $this->app->instance(ExceptionHandler::class, new class extends Handler{
-            public function __construct() {}
-            public function report(Exception $e) {}
+            public function __construct() 
+            {
+
+            }
+            public function report(Exception $e) 
+            {
+
+            }
             public function render($request, Exception $e)
             {
                 throw $e;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,12 @@
 
 namespace Tests;
 
+use Exception;
 use App\Models\Auth\Role;
 use App\Models\Auth\User;
+use App\Exceptions\Handler;
 use Spatie\Permission\Models\Permission;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 /**
@@ -63,5 +66,22 @@ abstract class TestCase extends BaseTestCase
         $this->actingAs($admin);
 
         return $admin;
+    }
+
+    /**
+     * Disables the exception handling function and throws the exception instead
+     * 
+     * @return Throwable $e
+     */
+    protected function disableExceptionHandling()
+    {
+        $this->app->instance(ExceptionHandler::class, new class extends Handler{
+            public function __construct() {}
+            public function report(Exception $e) {}
+            public function render($request, Exception $e)
+            {
+                throw $e;
+            }
+        });
     }
 }

--- a/tests/Unit/DisableExceptionHandlingTest.php
+++ b/tests/Unit/DisableExceptionHandlingTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit;
 use Tests\TestCase; 
 use Illuminate\Foundation\Testing\RefreshDatabase;
  
-Class DisableExceptionHandlingTest extends TestCase
+class DisableExceptionHandlingTest extends TestCase
 {
     use RefreshDatabase;
     
@@ -17,8 +17,7 @@ Class DisableExceptionHandlingTest extends TestCase
             $this->disableExceptionHandling();
             $response = $this->get('admin');
             $response->assertStatus(302);
-        }
-        catch(\Exception $ex){
+        } catch(\Exception $ex) {
             $this->assertEquals('Unauthenticated.', $ex->getMessage());
         }
     }

--- a/tests/Unit/DisableExceptionHandlingTest.php
+++ b/tests/Unit/DisableExceptionHandlingTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit;
+ 
+use Tests\TestCase; 
+use Illuminate\Foundation\Testing\RefreshDatabase;
+ 
+Class DisableExceptionHandlingTest extends TestCase
+{
+    use RefreshDatabase;
+    
+    /** @test */
+    public function check_if_disable_exception_handling_works()
+    {
+        try {
+            //With disable exception handling enabled, route does not redirect, instead throws an exception
+            $this->disableExceptionHandling();
+            $response = $this->get('admin');
+            $response->assertStatus(302);
+        }
+        catch(\Exception $ex){
+            $this->assertEquals('Unauthenticated.', $ex->getMessage());
+        }
+    }
+}

--- a/tests/Unit/DisableExceptionHandlingTest.php
+++ b/tests/Unit/DisableExceptionHandlingTest.php
@@ -1,24 +1,24 @@
 <?php
 
 namespace Tests\Unit;
- 
-use Tests\TestCase; 
+
+use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
- 
+
 class DisableExceptionHandlingTest extends TestCase
 {
     use RefreshDatabase;
-    
+
     /** @test */
     public function check_if_disable_exception_handling_works()
     {
         try {
-            //With disable exception handling enabled, route does not redirect, instead throws an exception
+            //With disable exception handling enabled, route does not redirect, instead throws an exception.
             $this->disableExceptionHandling();
             $response = $this->get('admin');
             $response->assertStatus(302);
-        } catch(\Exception $ex) {
-            $this->assertEquals('Unauthenticated.', $ex->getMessage());
+        } catch (\Exception $ex) {
+            $this->assertSame('Unauthenticated.', $ex->getMessage());
         }
     }
 }


### PR DESCRIPTION
### Enhancement
**Brief**: Added `disableExceptionHandling` function to `TestCase.php`
**Explanation**: While testing, some of the test function needs the exception handling to be turned off. And doing it manually leaves a room for error and when code is push to server without undoing the handler change it has cause havoc. So, I have added a function called `disableExceptionHandling` in the `TestCase.php` which just disables the exception handling with a single line of code, where it is needed. 

Also, I have added a test file to test the above function.
Hope, others will find it useful :)