### PR TITLE
Use default Socialite Google scopes

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -85,17 +85,6 @@ return [
         'client_id' => env('GOOGLE_CLIENT_ID'),
         'client_secret' => env('GOOGLE_CLIENT_SECRET'),
         'redirect' => env('GOOGLE_REDIRECT'),
-
-        /*
-         * Only allows google to grab email address
-         * Default scopes array also has: 'https://www.googleapis.com/auth/plus.login'
-         * https://medium.com/@njovin/fixing-laravel-socialite-s-google-permissions-2b0ef8c18205
-         */
-        'scopes' => [
-            'https://www.googleapis.com/auth/plus.me',
-            'https://www.googleapis.com/auth/plus.profile.emails.read',
-        ],
-
         'with' => [],
     ],
 


### PR DESCRIPTION
Google plus API seems to be gone, default Socialite values seem to work without causing warnings.

