### PR TITLE
[Translations] Fix typo in de/labels.php

### DIFF
--- a/resources/lang/de/labels.php
+++ b/resources/lang/de/labels.php
@@ -29,7 +29,7 @@ return [
         'show' => 'Anzeigen',
         'toggle_navigation' => 'Navigation umschalten',
         'more' => 'Mehr',
-        'greate_new' => 'Neue erstellen',
+        'create_new' => 'Neue erstellen',
     ],
 
     'backend' => [


### PR DESCRIPTION
'greate_new' should be 'create_new'

# Is this a fix, enhancement or language pack?
This is a **fix** of the typo that came with [this commit](https://github.com/rappasoft/laravel-boilerplate/commit/88ac38ea8c05398b8b8971b4eacf85f44087d293).
