### PR TITLE
Fix critical issue social login

### DIFF
--- a/app/Repositories/Frontend/Auth/UserRepository.php
+++ b/app/Repositories/Frontend/Auth/UserRepository.php
@@ -246,6 +246,17 @@ class UserRepository extends BaseRepository
      */
     public function findOrCreateProvider($data, $provider)
     {
+        $socialAccount = SocialAccount::where(
+            [
+                'provider' => $provider,
+                'provider_id' => $data->id,
+            ]
+        )->first();
+
+        if (!blank($socialAccount) && $user = $socialAccount->user) {
+            return $user;
+        }
+        
         // User email may not provided.
         $user_email = $data->email ?: "{$data->id}@{$provider}.com";
 


### PR DESCRIPTION

We just assume that user can change email on their social like facebook,

This fix will able to fetch same data even they update the email of their social, they can fetch same data as they first register here via social