### PR TITLE
Add main as a branch to run the workflow on

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   push:
     branches:
+      - main
       - master
       - development
 


### PR DESCRIPTION
Hi! I noticed that on new repos the Github workflow is not running, since the new repos use "main" instead of the "master" branch. I believe adding the "main" branch might be useful :D 