### PR TITLE
Fixes 2fa disabled, but still shows when route is '/admin'

### DIFF
--- a/app/Domains/Auth/Http/Middleware/TwoFactorAuthenticationStatus.php
+++ b/app/Domains/Auth/Http/Middleware/TwoFactorAuthenticationStatus.php
@@ -23,7 +23,7 @@ class TwoFactorAuthenticationStatus
         }
 
         // If the backend does not require 2FA than continue
-        if ($status === 'enabled' && $request->is('admin/*') && ! config('boilerplate.access.user.admin_requires_2fa')) {
+        if ($status === 'enabled' && $request->is('admin*') && ! config('boilerplate.access.user.admin_requires_2fa')) {
             return $next($request);
         }
 


### PR DESCRIPTION
When logging in when ADMIN_REQUIRES_2FA=false in .env, the successful admin redirect could point to "/admin", but the TwoFactorAuthenticationStatus middleware checks for 

`$request->is('admin/*')`

which fails the test and shows the 2fa requirement page. Going to any other admin page does not show the 2fa requirement page. This small change catches the 'admin' url by changing 

`$request->is('admin/*')`

to 

`$request->is('admin*')`

