### PR TITLE
Load Livewire scripts before AlpineJS (#1567)

### DIFF
--- a/resources/views/backend/layouts/app.blade.php
+++ b/resources/views/backend/layouts/app.blade.php
@@ -40,8 +40,8 @@
     @stack('before-scripts')
     <script src="{{ mix('js/manifest.js') }}"></script>
     <script src="{{ mix('js/vendor.js') }}"></script>
-    <script src="{{ mix('js/backend.js') }}"></script>
     <livewire:scripts />
+    <script src="{{ mix('js/backend.js') }}"></script>
     @stack('after-scripts')
 </body>
 </html>

--- a/resources/views/frontend/layouts/app.blade.php
+++ b/resources/views/frontend/layouts/app.blade.php
@@ -33,8 +33,8 @@
     @stack('before-scripts')
     <script src="{{ mix('js/manifest.js') }}"></script>
     <script src="{{ mix('js/vendor.js') }}"></script>
-    <script src="{{ mix('js/frontend.js') }}"></script>
     <livewire:scripts />
+    <script src="{{ mix('js/frontend.js') }}"></script>
     @stack('after-scripts')
 </body>
 </html>


### PR DESCRIPTION
During booting of backend, I came to notice a warning thrown by test routines of Livewire scripts getting loaded before AlphineJS. It's a recommended practice to load AlphineJS _after_ Livewire, hence the purpose of this PR.

All it does is change the ordering of scripts being called in the blade directive, making sure the livewire scripts are loaded before AlphineJS's.

Ref: https://laravel-livewire.com/docs/2.x/alpine-js

Error message attempted at curbing:

```
Livewire: It looks like AlpineJS has already been loaded. Make sure Livewire's scripts are loaded before Alpine.\n\n Reference docs for more info: http://laravel-livewire.com/docs/alpine-js
(anonymous) @ test:452
setTimeout (async)
(anonymous) @ test:451
```

Thanks for your time.