### PR TITLE
Improve visibility of the 2FA secret key

### DIFF
--- a/resources/views/frontend/user/account/tabs/two-factor-authentication/enable.blade.php
+++ b/resources/views/frontend/user/account/tabs/two-factor-authentication/enable.blade.php
@@ -25,7 +25,10 @@
                                 <div class="text-center">
                                     {!! $qrCode !!}
 
-                                    <p><i class="fa fa-key"> {{ $secret }}</i></p>
+                                    <p class="text-monospace">
+                                        <i class="fa fa-key"></i>
+                                        {{ $secret }}
+                                    </p>
                                 </div>
                             </div><!--col-->
                         </div><!--row-->


### PR DESCRIPTION
The font was displayed incorrectly because the secret key was between the `<i>` tag. I've also added the `text-monospace` for a better look.